### PR TITLE
Fix for nvidia 560 driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ wallock_test
 wallock_bench
 .gdb_history
 .cache
+cpm-package-lock.cmake

--- a/src/display/Display.cpp
+++ b/src/display/Display.cpp
@@ -472,6 +472,8 @@ auto wall::Display::swap_wallpaper_to_lock() -> void {
         screen->destroy_wallpaper_surface();
     }
 
+    roundtrip();
+
     for (const auto& screen : m_registry->get_screens()) {
         if (is_swap_compatible && last_files_for_screens.contains(screen->get_output_state().m_global_name)) {
             auto resource = std::move(last_files_for_screens[screen->get_output_state().m_global_name]);
@@ -518,6 +520,8 @@ auto wall::Display::swap_lock_to_wallpaper() -> void {
 
         screen->destroy_lock_surface();
     }
+
+    roundtrip();
 
     for (const auto& screen : m_registry->get_screens()) {
         if (is_swap_compatible && last_files_for_screens.contains(screen->get_output_state().m_global_name)) {

--- a/src/display/Display.hpp
+++ b/src/display/Display.hpp
@@ -69,10 +69,6 @@ class Display {
    protected:
     [[nodiscard]] auto get_config() const -> const Config&;
 
-    [[nodiscard]] auto create_pending_surfaces() -> bool;
-
-    auto recreate_failed_renderers(Screen* screen) -> void;
-
     auto close_loop() -> void;
 
     auto unlock() -> void;

--- a/src/display/Display.hpp
+++ b/src/display/Display.hpp
@@ -71,6 +71,10 @@ class Display {
    protected:
     [[nodiscard]] auto get_config() const -> const Config&;
 
+    auto swap_surfaces() -> void;
+
+    auto render() -> void;
+
     auto recreate_failed_renderers(Screen* screen) -> void;
 
     auto close_loop() -> void;

--- a/src/display/Display.hpp
+++ b/src/display/Display.hpp
@@ -46,6 +46,8 @@ class Display {
 
     [[nodiscard]] auto get_lock_mut() -> Lock*;
 
+    [[nodiscard]] auto get_lock_safe() -> Lock*;
+
     [[nodiscard]] auto get_primary_state_mut() -> PrimaryDisplayState*;
 
     [[nodiscard]] auto get_renderer_creator_mut() -> RendererCreator*;
@@ -68,6 +70,8 @@ class Display {
 
    protected:
     [[nodiscard]] auto get_config() const -> const Config&;
+
+    auto recreate_failed_renderers(Screen* screen) -> void;
 
     auto close_loop() -> void;
 

--- a/src/display/Screen.cpp
+++ b/src/display/Screen.cpp
@@ -154,7 +154,7 @@ auto wall::Screen::on_done() -> void {
     LOG_DEBUG("Screen::on_done: {}", m_output_state.m_name);
 
     if (m_display->is_locked()) {
-        create_lock_surface(m_display->get_lock_mut());
+        create_lock_surface(m_display->get_lock_safe());
     } else {
         create_wallpaper_surface();
     }

--- a/src/display/Screen.cpp
+++ b/src/display/Screen.cpp
@@ -153,6 +153,12 @@ auto wall::Screen::on_done() -> void {
     }
     LOG_DEBUG("Screen::on_done: {}", m_output_state.m_name);
 
+    if (m_display->is_locked()) {
+        create_lock_surface(m_display->get_lock_mut());
+    } else {
+        create_wallpaper_surface();
+    }
+
     m_is_done = true;
     m_display->wake();
 }

--- a/src/display/Screen.cpp
+++ b/src/display/Screen.cpp
@@ -257,11 +257,17 @@ auto wall::Screen::on_state_change(State state) -> void {
 }
 
 auto wall::Screen::destroy_lock_surface() -> void {
+    if (m_lock_surface->get_mpv_resource() != nullptr) {
+        m_lock_surface->get_mpv_resource()->set_surface(nullptr);
+    }
     m_lock_surface->destroy_resources();
     m_lock_surface = nullptr;
 }
 
 auto wall::Screen::destroy_wallpaper_surface() -> void {
+    if (m_wallpaper_surface->get_mpv_resource() != nullptr) {
+        m_wallpaper_surface->get_mpv_resource()->set_surface(nullptr);
+    }
     m_wallpaper_surface->destroy_resources();
     m_wallpaper_surface = nullptr;
 }

--- a/src/mpv/MpvEventHandler.cpp
+++ b/src/mpv/MpvEventHandler.cpp
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <cstdint>
 
+#include "util/Log.hpp"
+
 namespace {
 std::atomic_uint64_t g_id = 0UL;
 }

--- a/src/mpv/MpvResource.cpp
+++ b/src/mpv/MpvResource.cpp
@@ -200,7 +200,6 @@ auto wall::MpvResource::setup_update_callback() -> void {
         mpv_render_context_update(get_mpv_context());
         if (m_surface != nullptr && m_surface->get_renderer_mut() != nullptr) {
             m_surface->get_renderer_mut()->set_is_dirty(true);
-            m_surface->get_renderer_mut()->render(get_surface());
         }
     });
 

--- a/src/mpv/MpvResource.cpp
+++ b/src/mpv/MpvResource.cpp
@@ -52,6 +52,10 @@ auto wall::MpvResource::play() -> void {
     if (m_is_paused) {
         send_mpv_cmd("set", "pause", "no");
     }
+
+    if (m_is_single_frame) {
+        send_mpv_cmd("seek", "0", "absolute");
+    }
     m_is_paused = false;
 }
 

--- a/src/mpv/MpvResource.hpp
+++ b/src/mpv/MpvResource.hpp
@@ -19,7 +19,7 @@ class Surface;
 class MpvResource : public std::enable_shared_from_this<MpvResource> {
    public:
     MpvResource(const Config& config, Display* display, Surface* surface);
-    ~MpvResource();
+    virtual ~MpvResource();
 
     MpvResource(const MpvResource&) = delete;
     auto operator=(const MpvResource&) -> MpvResource& = delete;

--- a/src/overlay/CairoBarElement.cpp
+++ b/src/overlay/CairoBarElement.cpp
@@ -59,8 +59,10 @@ auto wall::CairoBarElement::update_settings() -> void {
     m_font_color = wall_conf_get_with_fallback(get_config(), lock_bar, font_color, font, color);
 }
 
-auto wall::CairoBarElement::get_buffer_size(int32_t width, int32_t height, const CairoFontCache& font_cache, const std::string& message) const
-    -> std::pair<int32_t, int32_t> {
+auto wall::CairoBarElement::get_buffer_size(int32_t width,
+                                            int32_t height,
+                                            const CairoFontCache& font_cache,
+                                            const std::string& message) const -> std::pair<int32_t, int32_t> {
     auto* font_face = font_cache.get_font_face();
     auto font_size = font_cache.get_font_size();
     auto* cairo = font_cache.get_font_cairo_state()->get_cairo();
@@ -87,8 +89,10 @@ auto wall::CairoBarElement::get_buffer_size(int32_t width, int32_t height, const
     return {buffer_width, buffer_height};
 }
 
-auto wall::CairoBarElement::get_position_size(int32_t width, int32_t height, int32_t buffer_width, int32_t buffer_height) const
-    -> std::pair<int32_t, int32_t> {
+auto wall::CairoBarElement::get_position_size(int32_t width,
+                                              int32_t height,
+                                              int32_t buffer_width,
+                                              int32_t buffer_height) const -> std::pair<int32_t, int32_t> {
     auto subsurf_xpos = 0;
     auto subsurf_ypos = 0;
 

--- a/src/overlay/CairoBarElement.hpp
+++ b/src/overlay/CairoBarElement.hpp
@@ -27,11 +27,15 @@ class CairoBarElement {
 
     auto draw(cairo_t* cairo, double width, double height, const CairoFontCache& font_cache, const std::string& message) const -> void;
 
-    [[nodiscard]] auto get_position_size(int32_t width, int32_t height, int32_t buffer_width, int32_t buffer_height) const
-        -> std::pair<int32_t, int32_t>;
+    [[nodiscard]] auto get_position_size(int32_t width,
+                                         int32_t height,
+                                         int32_t buffer_width,
+                                         int32_t buffer_height) const -> std::pair<int32_t, int32_t>;
 
-    [[nodiscard]] auto get_buffer_size(int32_t width, int32_t height, const CairoFontCache& font_cache, const std::string& message) const
-        -> std::pair<int32_t, int32_t>;
+    [[nodiscard]] auto get_buffer_size(int32_t width,
+                                       int32_t height,
+                                       const CairoFontCache& font_cache,
+                                       const std::string& message) const -> std::pair<int32_t, int32_t>;
 
    protected:
     [[nodiscard]] auto get_config() const -> const Config&;

--- a/src/render/RendererEGL.cpp
+++ b/src/render/RendererEGL.cpp
@@ -20,7 +20,6 @@ wall::RendererEGL::RendererEGL(const Config& config,
     : Renderer(config, display, std::move(surface_egl)), m_egl_display{egl_display}, m_egl_context{egl_context} {}
 
 auto wall::RendererEGL::render([[maybe_unused]] Surface* surface) -> void {
-    LOG_DEBUG("Rendering");
     if (eglMakeCurrent(m_egl_display, get_surface_egl().get_egl_surface(), get_surface_egl().get_egl_surface(), m_egl_context) == EGL_FALSE) {
         LOG_FATAL("Couldn't make EGL context current");
         return;
@@ -38,16 +37,15 @@ auto wall::RendererEGL::render([[maybe_unused]] Surface* surface) -> void {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glClear(GL_COLOR_BUFFER_BIT);
 
-    /*     red += 1.0; */
-    /*     green += 1.0; */
-    /*     blue += 1.0; */
+    red += 1.0;
+    green += 1.0;
+    blue += 1.0;
 
-    /*     red = fmod(red, 255.0); */
-    /*     green = fmod(green, 255.0); */
-    /*     blue = fmod(blue, 255.0); */
+    red = fmod(red, 255.0);
+    green = fmod(green, 255.0);
+    blue = fmod(blue, 255.0);
 
-    /* setup_next_frame_callback(surface); */
-    LOG_DEBUG("Rendering color: {} {} {}", red, green, blue);
+    setup_next_frame_callback(surface);
     eglSwapBuffers(m_egl_display, get_surface_egl().get_egl_surface());
     set_has_buffer(true);
 }

--- a/src/surface/WallpaperSurface.cpp
+++ b/src/surface/WallpaperSurface.cpp
@@ -106,6 +106,7 @@ auto wall::WallpaperSurface::on_configure(uint32_t serial, uint32_t width, uint3
 
     if (get_renderer_mut() == nullptr) {
         get_display()->get_renderer_creator_mut()->create_mpv_renderer(this);
+        /* get_display()->get_renderer_creator_mut()->create_egl_renderer(this); */
     }
 
     set_is_configured(true);

--- a/src/util/FileUtils.cpp
+++ b/src/util/FileUtils.cpp
@@ -49,8 +49,9 @@ auto wall::FileUtils::get_expansion_cache(const std::filesystem::path& file) -> 
     return get_expansion(file, k_cache_dirs);
 }
 
-auto wall::FileUtils::get_expansion(const std::filesystem::path& file, const std::vector<std::filesystem::path>& root_dirs, bool is_exists)
-    -> std::optional<std::filesystem::path> {
+auto wall::FileUtils::get_expansion(const std::filesystem::path& file,
+                                    const std::vector<std::filesystem::path>& root_dirs,
+                                    bool is_exists) -> std::optional<std::filesystem::path> {
     if (file.is_absolute()) {
         return file;
     }
@@ -117,8 +118,8 @@ auto wall::FileUtils::expand_path(const std::filesystem::path& path) -> std::opt
     return result;
 }
 
-auto wall::FileUtils::get_all_files(const std::filesystem::path& dir, const std::set<std::string>& valid_extensions)
-    -> std::deque<std::filesystem::path> {
+auto wall::FileUtils::get_all_files(const std::filesystem::path& dir,
+                                    const std::set<std::string>& valid_extensions) -> std::deque<std::filesystem::path> {
     std::deque<std::filesystem::path> files;
     const auto expanded_path_opt = FileUtils::expand_path(dir);
     if (!expanded_path_opt) {

--- a/src/util/FileUtils.hpp
+++ b/src/util/FileUtils.hpp
@@ -22,11 +22,12 @@ class FileUtils {
 
     static auto get_default_runtime_dir() -> std::filesystem::path;
 
-    static auto get_all_files(const std::filesystem::path& dir, const std::set<std::string>& valid_extensions = {})
-        -> std::deque<std::filesystem::path>;
+    static auto get_all_files(const std::filesystem::path& dir,
+                              const std::set<std::string>& valid_extensions = {}) -> std::deque<std::filesystem::path>;
 
    private:
-    static auto get_expansion(const std::filesystem::path& file, const std::vector<std::filesystem::path>& root_dirs, bool is_exists = false)
-        -> std::optional<std::filesystem::path>;
+    static auto get_expansion(const std::filesystem::path& file,
+                              const std::vector<std::filesystem::path>& root_dirs,
+                              bool is_exists = false) -> std::optional<std::filesystem::path>;
 };
 }  // namespace wall

--- a/src/util/Loop.cpp
+++ b/src/util/Loop.cpp
@@ -248,13 +248,14 @@ auto wall::Loop::add_poll_pipe(std::function<void(loop::PollPipe*, const std::ve
     return add_handle(std::make_unique<loop::PollPipe>(std::move(callback)));
 }
 
-auto wall::Loop::add_timer(std::chrono::milliseconds initial_delay, std::chrono::milliseconds interval, std::function<void(loop::Timer*)> callback)
-    -> loop::Timer* {
+auto wall::Loop::add_timer(std::chrono::milliseconds initial_delay,
+                           std::chrono::milliseconds interval,
+                           std::function<void(loop::Timer*)> callback) -> loop::Timer* {
     return add_handle(std::make_unique<loop::Timer>(m_now + initial_delay, interval, std::move(callback)));
 }
 
-auto wall::Loop::add_unix_socket(const std::filesystem::path& path, std::function<void(loop::UnixSocket*, const std::string&)> callback)
-    -> loop::UnixSocket* {
+auto wall::Loop::add_unix_socket(const std::filesystem::path& path,
+                                 std::function<void(loop::UnixSocket*, const std::string&)> callback) -> loop::UnixSocket* {
     return add_handle(std::make_unique<loop::UnixSocket>(this, path, std::move(callback)));
 }
 

--- a/src/util/Loop.hpp
+++ b/src/util/Loop.hpp
@@ -47,8 +47,9 @@ class Loop {
 
     auto add_unix_socket(const std::filesystem::path& path, std::function<void(loop::UnixSocket*, const std::string&)> callback) -> loop::UnixSocket*;
 
-    auto add_timer(std::chrono::milliseconds initial_delay, std::chrono::milliseconds interval, std::function<void(loop::Timer*)> callback)
-        -> loop::Timer*;
+    auto add_timer(std::chrono::milliseconds initial_delay,
+                   std::chrono::milliseconds interval,
+                   std::function<void(loop::Timer*)> callback) -> loop::Timer*;
 
    protected:
     auto poll_fds(std::chrono::milliseconds min_timeout) -> void;


### PR DESCRIPTION
Removing hacks that were needed for older nvidia drivers, now that explicit sync is supported they are no longer needed. The hacks were causing issues with nvidia 560 drivers.